### PR TITLE
Fix #12 Added Bsc class

### DIFF
--- a/src/Calculate/Bsc.cs
+++ b/src/Calculate/Bsc.cs
@@ -1,0 +1,67 @@
+﻿// https://strusoft.com/
+using System;
+using System.IO;
+using System.Xml.Serialization;
+
+
+namespace FemDesign.Calculate
+{
+    /// <summary>
+    /// fdscript.xsd
+    /// fdscript root
+    /// </summary>
+    [XmlRoot("fdscript")]
+    public class Bsc
+    {
+        [XmlAttribute("noNamespaceSchemaLocation", Namespace = "http://www.w3.org/2001/XMLSchema-instance")]
+        public const string XmlAttrib = "fdscript.xsd";
+        [XmlElement("fdscriptheader", Order = 1)]
+        public FdScriptHeader FdScriptHeader { get; set; } // FDSCRIPTHEADER
+        [XmlElement("cmddoctable", Order = 2)]
+        public DocTable DocTable { get; set; } // CMDDOCKTABLE
+        [XmlElement("cmdendsession", Order = 3)]
+        public CmdEndSession CmdEndSession { get; set; } // CMDENDSESSION
+        [XmlIgnore]
+        internal string Cwd { get; set; } // current work directory, string
+        [XmlIgnore]
+        internal string BscPath { get; set; } // path to fdscript file, string
+
+        /// <summary>
+        /// Parameterless constructor for serialization.
+        /// </summary>
+        private Bsc()
+        {
+
+        }
+
+        public Bsc(ResultType resultType, string bscPath)
+        {
+            if (Path.GetExtension(bscPath) != ".bsc")
+            {
+                throw new ArgumentException($"File path must be '.bsc' but got '{bscPath}'");
+            }
+            BscPath = bscPath;
+            Cwd = Path.GetDirectoryName(bscPath);
+            DocTable = new DocTable(resultType);
+            FdScriptHeader = new FdScriptHeader("Generated script.", Path.Combine(Cwd, "logfile.log"));
+            CmdEndSession = new CmdEndSession();
+        }
+
+        public Bsc(ResultType resultType, int caseIndex, string bscPath) : this(resultType, bscPath)
+        {
+            DocTable.CaseIndex = caseIndex;
+        }
+
+        /// <summary>
+        /// Serialize bsc.
+        /// </summary>
+        public void SerializeBsc()
+        {
+            XmlSerializer serializer = new XmlSerializer(typeof(Bsc));
+            using (TextWriter writer = new StreamWriter(this.BscPath))
+            {
+                serializer.Serialize(writer, this);
+            }
+        }
+    }
+}

--- a/src/Calculate/Bsc.cs
+++ b/src/Calculate/Bsc.cs
@@ -17,8 +17,23 @@ namespace FemDesign.Calculate
         public const string XmlAttrib = "fdscript.xsd";
         [XmlElement("fdscriptheader", Order = 1)]
         public FdScriptHeader FdScriptHeader { get; set; } // FDSCRIPTHEADER
+
         [XmlElement("cmddoctable", Order = 2)]
-        public DocTable DocTable { get; set; } // CMDDOCTABLE
+        public CmdDocTable _cmdDocTable;  // CMDDOCTABLE
+
+        [XmlIgnore]
+        public DocTable DocTable
+        {
+            get
+            {
+                return _cmdDocTable.DocTable;
+            }
+            set
+            {
+                this._cmdDocTable = new CmdDocTable(value);
+            }
+        }
+
         [XmlElement("cmdendsession", Order = 3)]
         public CmdEndSession CmdEndSession { get; set; } // CMDENDSESSION
         [XmlIgnore]

--- a/src/Calculate/Bsc.cs
+++ b/src/Calculate/Bsc.cs
@@ -18,7 +18,7 @@ namespace FemDesign.Calculate
         [XmlElement("fdscriptheader", Order = 1)]
         public FdScriptHeader FdScriptHeader { get; set; } // FDSCRIPTHEADER
         [XmlElement("cmddoctable", Order = 2)]
-        public DocTable DocTable { get; set; } // CMDDOCKTABLE
+        public DocTable DocTable { get; set; } // CMDDOCTABLE
         [XmlElement("cmdendsession", Order = 3)]
         public CmdEndSession CmdEndSession { get; set; } // CMDENDSESSION
         [XmlIgnore]

--- a/src/Calculate/DocTable.cs
+++ b/src/Calculate/DocTable.cs
@@ -6,10 +6,9 @@ namespace FemDesign.Calculate
 {
 
     /// <summary>
-    /// fdscript.xsd
-    /// bsc root
+    /// doctable
     /// </summary>
-    [XmlRoot("doctable")]
+    [XmlElement("doctable")]
     public class DocTable
     {
         [XmlIgnore]

--- a/src/Calculate/DocTable.cs
+++ b/src/Calculate/DocTable.cs
@@ -1,0 +1,41 @@
+﻿// https://strusoft.com/
+using System.Xml.Serialization;
+
+
+namespace FemDesign.Calculate
+{
+
+    /// <summary>
+    /// fdscript.xsd
+    /// bsc root
+    /// </summary>
+    [XmlRoot("doctable")]
+    public class DocTable
+    {
+        [XmlIgnore]
+        private const int ALL = -65536;
+        [XmlElement("listproc")]
+        public ResultType ListProc { get; set; }
+        [XmlElement("index")]
+        public int CaseIndex { get; set; }
+
+        /// <summary>
+        /// Parameterless constructor for serialization.
+        /// </summary>
+        private DocTable()
+        {
+
+        }
+
+        /// <summary>
+        /// DocTable constructor
+        /// </summary>
+        /// <param name="resultType"></param>
+        /// <param name="caseIndex">Defaults to all loadcases or loadcombinations</param>
+        public DocTable(ResultType resultType, int caseIndex = ALL)
+        {
+            ListProc = resultType;
+            CaseIndex = caseIndex;
+        }
+    }
+}

--- a/src/Calculate/DocTable.cs
+++ b/src/Calculate/DocTable.cs
@@ -14,10 +14,15 @@ namespace FemDesign.Calculate
     {
         [XmlIgnore]
         private const int ALL = -65536;
+        
         [XmlElement("listproc")]
         public ResultType ListProc { get; set; }
+        
         [XmlElement("index")]
         public int CaseIndex { get; set; }
+        
+        [XmlAttribute("command")]
+        public string Command { get; set; }
 
         /// <summary>
         /// Parameterless constructor for serialization.
@@ -36,6 +41,8 @@ namespace FemDesign.Calculate
         {
             ListProc = resultType;
             CaseIndex = caseIndex;
+            Command = "";
+            
         }
     }
 }

--- a/src/Calculate/DocTable.cs
+++ b/src/Calculate/DocTable.cs
@@ -15,7 +15,7 @@ namespace FemDesign.Calculate
         public DocTable DocTable { get; set; }
 
         [XmlAttribute("command")]
-        public string Command { get; set; }
+        public string _command = "; CXL $MODULE DOCTABLE";
 
         /// <summary>
         /// Parameterless constructor for serialization.
@@ -32,7 +32,6 @@ namespace FemDesign.Calculate
         public CmdDocTable(DocTable docTable)
         {
             this.DocTable = docTable;
-            this.Command = "";
         }
     }
     

--- a/src/Calculate/DocTable.cs
+++ b/src/Calculate/DocTable.cs
@@ -6,9 +6,40 @@ namespace FemDesign.Calculate
 {
 
     /// <summary>
+    /// cmddoctable
+    /// </summary>
+    [System.Serializable]
+    public class CmdDocTable
+    {   
+        [XmlElement("doctable", Order = 1)]
+        public DocTable DocTable { get; set; }
+
+        [XmlAttribute("command")]
+        public string Command { get; set; }
+
+        /// <summary>
+        /// Parameterless constructor for serialization.
+        /// </summary>
+        private CmdDocTable()
+        {
+
+        }
+
+        /// <summary>
+        /// CmdDocTable constructor
+        /// </summary>
+        /// <param name="docTable">DocTable</param>
+        public CmdDocTable(DocTable docTable)
+        {
+            this.DocTable = docTable;
+            this.Command = "";
+        }
+    }
+    
+    /// <summary>
     /// doctable
     /// </summary>
-    [XmlElement("doctable")]
+    [System.Serializable]
     public class DocTable
     {
         [XmlIgnore]
@@ -19,9 +50,6 @@ namespace FemDesign.Calculate
         
         [XmlElement("index")]
         public int CaseIndex { get; set; }
-        
-        [XmlAttribute("command")]
-        public string Command { get; set; }
 
         /// <summary>
         /// Parameterless constructor for serialization.
@@ -39,9 +67,7 @@ namespace FemDesign.Calculate
         public DocTable(ResultType resultType, int caseIndex = ALL)
         {
             ListProc = resultType;
-            CaseIndex = caseIndex;
-            Command = "";
-            
+            CaseIndex = caseIndex;            
         }
     }
 }

--- a/src/Calculate/ResultType.cs
+++ b/src/Calculate/ResultType.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FemDesign.Calculate
+{
+    public enum ResultType 
+    {
+        /* LOADCASES*/
+
+        /// <summary>
+        /// Bars, internal forces
+        /// </summary>
+        frCaseIntfBar_ListProc,
+
+        /* LOADCOMBINATIONS*/
+
+        /// <summary>
+        /// Labelled sections, internal forces
+        /// </summary>
+        frCombIntfResSection_ListProc
+    }
+}


### PR DESCRIPTION
Fix #12 Added Bsc class, and added ListProc enum as per #7

With this PR a Bsc object can be created and serialized to a bsc file. 


Note that the ListProc enum (`ResultType`) does **only** contain `frCaseIntfBar_ListProc` and `frCombIntfResSection_ListProc` in this PR. 