### PR TITLE
IFemDesignEntity and EntityBase cleanup

### DIFF
--- a/FemDesign.Core/GenericClasses/EntityBase.cs
+++ b/FemDesign.Core/GenericClasses/EntityBase.cs
@@ -10,20 +10,20 @@ namespace FemDesign
     /// entity_attribs
     /// </summary>
     [Serializable]
-    public partial class EntityBase : IFemDesignEntity
+    public abstract partial class EntityBase : IFemDesignEntity
     {
         [XmlAttribute("guid")]
         public Guid Guid { get; set; }
         [XmlAttribute("last_change")]
         public string _lastChange;
         [XmlIgnore]
-        internal DateTime LastChange
+        public DateTime LastChange
         {
             get
             {
                 return DateTime.Parse(this._lastChange);
             }
-            set
+            private set
             {
                 this._lastChange = value.ToString("yyyy-MM-ddTHH:mm:ss.fff", CultureInfo.InvariantCulture);
             }

--- a/FemDesign.Core/GenericClasses/IFemDesignEntity.cs
+++ b/FemDesign.Core/GenericClasses/IFemDesignEntity.cs
@@ -12,8 +12,20 @@ namespace FemDesign.GenericClasses
     public interface IFemDesignEntity
     {
         /// <summary>
+        /// Global Unique Id of entity
+        /// </summary>
+        Guid Guid { get; set; }
+
+        /// <summary>
         /// Invoke when an instance is created.
         /// </summary>
         void EntityCreated();
+
+        /// <summary>
+        /// Invoke when an instance is modified.
+        /// 
+        /// Changes timestamp and action.
+        /// </summary>
+        void EntityModified();
     }
 }

--- a/FemDesign.Core/Loads/LoadGroupTable.cs
+++ b/FemDesign.Core/Loads/LoadGroupTable.cs
@@ -10,7 +10,7 @@ namespace FemDesign.Loads
     /// load_group_table
     /// </summary>
     [System.Serializable]
-    public partial class LoadGroupTable: IFemDesignEntity
+    public partial class LoadGroupTable
     {
         [XmlAttribute("last_change")]
         public string _lastChange;
@@ -86,6 +86,17 @@ namespace FemDesign.Loads
         {
             LastChange = DateTime.UtcNow;
             Action = "added";
+        }
+
+        /// <summary>
+        /// Invoke when an instance is modified.
+        /// 
+        /// Changes timestamp and action.
+        /// </summary>
+        public void EntityModified()
+        {
+            this.LastChange = DateTime.UtcNow;
+            this.Action = "modified";
         }
     }
 }

--- a/FemDesign.Core/Loads/ModelGeneralLoadGroup.cs
+++ b/FemDesign.Core/Loads/ModelGeneralLoadGroup.cs
@@ -10,7 +10,7 @@ namespace FemDesign.Loads
     /// load_case (child of load_group_table)
     /// </summary>
     [System.Serializable]
-    public partial class ModelGeneralLoadGroup: GenericClasses.IFemDesignEntity
+    public partial class ModelGeneralLoadGroup
     {
         [XmlAttribute("name")]
         public string Name { get; set; }
@@ -28,7 +28,6 @@ namespace FemDesign.Loads
         /// </summary>
         public ModelGeneralLoadGroup()
         {
-            // parameterless constructor for serialization
         }
 
         /// <summary>
@@ -37,17 +36,9 @@ namespace FemDesign.Loads
         /// <param name="LoadGroup">Specific load group object</param>
         public ModelGeneralLoadGroup(LoadGroupBase LoadGroup)
         {
-            EntityCreated();
+            Guid = Guid.NewGuid();
             AddSpecificLoadGroup(LoadGroup, false);
             Name = LoadGroup.Name;
-        }
-
-        /// <summary>
-        /// Invoke when an instance is created.
-        /// 
-        public void EntityCreated()
-        {
-            Guid = Guid.NewGuid();
         }
 
         /// <summary>


### PR DESCRIPTION
- All classes of IFemDesignEntity should have Guid, EntityCreated() and EntityModified()
- Remove IFemDesignEntity from LoadGroupTable and ModelGeneralLoadGroup
- Make EntityBase abstract to prevent class from being constructed
- Make LastChange.set private